### PR TITLE
Show 'how to play' when first landing on the app

### DIFF
--- a/components/StartGame/StartGame.tsx
+++ b/components/StartGame/StartGame.tsx
@@ -1,14 +1,17 @@
+import { useAuth0 } from '@auth0/auth0-react';
 import { useRouter } from 'next/router';
 import { useMutation } from '../../convex/_generated';
 import Button from '../Button/Button';
 import Instructions from '../Instructions/Instructions';
 import Modal from '../Modal/Modal';
+import Spinner from '../Spinner/Spinner';
 import styles from './StartGame.module.scss';
 
 function StartGame() {
   const router = useRouter();
   const createGame = useMutation('createGame');
   const createOrJoinRandom = useMutation('createOrJoinRandom');
+  let { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
 
   const handleCreateGame = (e: any) => {
     e.preventDefault();
@@ -36,17 +39,29 @@ function StartGame() {
     go();
   };
 
+  // TODO: If no user (signed out) show sign in button instead of start game options.
+
+  if (isLoading) {
+    return <Spinner />;
+  }
+
   return (
     <Modal open>
       <Instructions />
       <form className={styles.actions}>
-        <Button onClick={handleCreateGame}>
-          Create a Game to Play a Friend
-        </Button>
-        <Button onClick={handleJoinGame}>Join a Friend&rsquo;s Game</Button>
-        <Button onClick={handleRandom}>
-          Play a Friendly Internet Stranger
-        </Button>
+        {isAuthenticated ? (
+          <>
+            <Button onClick={handleCreateGame}>
+              Create a Game to Play a Friend
+            </Button>
+            <Button onClick={handleJoinGame}>Join a Friend&rsquo;s Game</Button>
+            <Button onClick={handleRandom}>
+              Play a Friendly Internet Stranger
+            </Button>
+          </>
+        ) : (
+          <Button onClick={loginWithRedirect}>Log in to play</Button>
+        )}
       </form>
     </Modal>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,22 +1,14 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { Id } from 'convex-dev/values';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import StartGame from '../components/StartGame/StartGame';
 import { useConvex, useMutation } from '../convex/_generated';
 
 const Home: NextPage = () => {
-  const [game, setGame] = useState('');
-  const [error, setError] = useState('');
-  const router = useRouter();
   const convex = useConvex();
   let { isAuthenticated, isLoading, getIdTokenClaims } = useAuth0();
-  const [userId, setUserId] = useState<Id | null>(null);
   const storeUser = useMutation('storeUser');
-  const createGame = useMutation('createGame');
-  const createOrJoinRandom = useMutation('createOrJoinRandom');
 
   useEffect(() => {
     if (isLoading) {
@@ -32,12 +24,10 @@ const Home: NextPage = () => {
         // Recall that `storeUser` gets the user information via the `auth`
         // object on the server. You don't need to pass anything manually here.
         let id = await storeUser();
-        setUserId(id);
       });
     } else {
       // Tell the Convex client to clear all authentication state.
       convex.clearAuth();
-      setUserId(null);
     }
   }, [isAuthenticated, isLoading, getIdTokenClaims, convex, storeUser]);
 
@@ -48,7 +38,7 @@ const Home: NextPage = () => {
         <meta name="description" content="Word racing at its finest" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      {userId ? <StartGame /> : <p>TODO: Logged-out content.</p>}
+      <StartGame />
     </div>
   );
 };


### PR DESCRIPTION
Removes the temporary todo text and jumps right to "How to Play", which seems like a good enough place to start for now. The regular buttons to start playing are replaced with a "Log in to play" button while the user is logged out.

![image](https://user-images.githubusercontent.com/1382445/167162035-7e6668f0-95cf-4526-8670-66c342c2021b.png)