### PR TITLE
Fix footer link

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -6,12 +6,10 @@ import styles from './Footer.module.scss';
 function Footer() {
   return (
     <footer className={styles.root}>
-      <Link href="https://convex.dev/" passHref>
-        <a>
-          Built with{' '}
-          <Image src="/convex.svg" width="94" height="17" alt="Convex logo" />
-        </a>
-      </Link>
+      <a href="https://convex.dev/">
+        Built with{' '}
+        <Image src="/convex.svg" width="94" height="17" alt="Convex logo" />
+      </a>
     </footer>
   );
 }


### PR DESCRIPTION
Replaces the `Link` component with a standard `a` element. This is an external link, so it doesn't need to do anything special with Next's routing system. It's just a link.