### PR TITLE
Display a message on smaller screens

### DIFF
--- a/components/App/App.module.scss
+++ b/components/App/App.module.scss
@@ -14,10 +14,14 @@
   }
 
   .modal {
-    display: block;
+    display: flex;
+  }
+
+  .modalContent {
     color: var(--color-white);
     font-size: var(--font-size-larger);
     font-weight: var(--font-weight-semibold);
-    max-width: 400px;
+    max-width: 300px;
+    text-align: center;
   }
 }

--- a/components/App/App.tsx
+++ b/components/App/App.tsx
@@ -17,8 +17,10 @@ function App({ children }: AppProps) {
         <Footer />
       </div>
       <Modal className={styles.modal} open>
-        Fast5 is not yet playable on mobile devices. Please try again from a
-        larger screen.
+        <div className={styles.modalContent}>
+          Fast5 is not yet playable on mobile devices. Please try again from a
+          larger screen.
+        </div>
       </Modal>
     </>
   );

--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -9,8 +9,10 @@ type ModalProps = {
 
 function Modal({ children, open = false, className }: ModalProps) {
   return (
-    <div className={classNames(styles.root, { [styles.closed]: !open })}>
-      <div className={classNames(styles.modal, className)}>{children}</div>
+    <div
+      className={classNames(styles.root, { [styles.closed]: !open }, className)}
+    >
+      <div className={styles.modal}>{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
Displays a message on screens that are too small for the design. This is currently defined as anything with a width of 1200px or less, or a height of 850px or less.

## Screenshots
The game is playable at the minimum screen size:
![image](https://user-images.githubusercontent.com/1382445/168113186-8e333191-aa29-48c0-a5de-7be2f50eec0b.png)

At smaller sizes the game is replaced with a modal:
![image](https://user-images.githubusercontent.com/1382445/168113369-38f08a9e-58ab-4445-9780-3587ef89bf09.png)
